### PR TITLE
Build on intro context

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 <img src="Images/Partydonk.png" width="320" alt="Partydonk Logo" />
 
-This project is lays down foundational features and changes that we want to bring to .NET to support both deep learning workloads and scientific workloads that currently make the use of .NET obnoxious in this space.
+**For deep learning and scientific workloads, we want to make .NET both a natural fit and a delight to use.**
 
-This draws both from capabilities that have been requested in the past, and both the implementations and designs that have been incorporated into other languages, notably Swift both as part of Google’s efforts with Swift for TensorFlow as well as Apple’s work on Swift Numerics that work in concert.
+These are both growth areas with needs .NET is well placed to service. However; without changes, using .NET is difficult and not a first choice for these domains, and the high level of development friction does not bring joy for developers where .NET is currently their preferred platform. 
+
+*This project lays down foundational features and changes that we want to bring to .NET to support both deep learning workloads and scientific workloads to make it both a natural fit and a delight to use.*
+
+These proposals draw both from capabilities that have been requested in the past, and both the implementations and designs that have been incorporated into other languages, notably Swift both as part of Google’s efforts with Swift for TensorFlow as well as Apple’s work on Swift Numerics that work in concert.
 
 These are the capabilities that we want to introduce into our runtimes and languages, a more detailed description follows this text.   These capabilities are generally designed to be framework neutral, and could be used with different deep learning and scientific libraries.
 


### PR DESCRIPTION
Start with a call to action to that applies as a general mission statement to continue and build on C# position as one of the most loved languages*:

> **For deep learning and scientific workloads, we want to make .NET both a natural fit and a delight to use.**

While *"make the use of .NET obnoxious in this space"* is correct; its strong specific wording may become an often quoted out of context haunting phrase. Change it to a "why" statement with a more positive twist, highlighting two groups: 
1. Developers already in these domains who may be new to .NET 
2. Current .NET developers who may be moving to these domains

> These are both growth areas with needs .NET is well placed to service. However; without changes, using .NET is difficult and not a first choice for these domains, and the high level of development friction does not bring joy for developers where .NET is currently their preferred platform.

Although we use the phrase *"a first choice"* for framing; we do not use the definite *"the first choice"*; or refer to the positional in the mission statement and instead use the phrase *"a natural fit"* as .NET is collaborative with other platforms not competitive. Indeed interop is one of .NET's strong points and one of the items is improving interop with Python.

The goal is for people to *want* to use .NET for these workloads and not just because everyone else is, or it is what the developer or business are used to.

Having established where we want to be; we begin the "how"/"what" restating that is accomplishing the goals:

> *This project lays down foundational features and changes that we want to bring to .NET to support both deep learning workloads and scientific workloads to make it both a natural fit and a delight to use.*
---

\* https://visualstudiomagazine.com/articles/2019/06/18/jetbrains-survey.aspx